### PR TITLE
GH_TOKEN

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -19,11 +19,11 @@ jobs:
     steps:
       - name: Get current date
         id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+        run: echo "$(date +'%Y-%m-%d')"
       - name: Create Draft Release
         id: create-draft-release
         env: 
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: prod-${{ steps.date.outputs.date }}
           RELEASE_NAME: prod-${{ steps.date.outputs.date }}
         run: |


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/release-draft.yml` file to update the way the current date is set and to modify the environment variable used for the GitHub token.

Workflow improvements:

* [`.github/workflows/release-draft.yml`](diffhunk://#diff-4bdc03a5e7ae81f88649acd20d9b3cac01b9e1f388daeb6bf8a07c3fedadf71fL22-R26): Updated the command to set the current date to use a simpler echo statement.
* [`.github/workflows/release-draft.yml`](diffhunk://#diff-4bdc03a5e7ae81f88649acd20d9b3cac01b9e1f388daeb6bf8a07c3fedadf71fL22-R26): Changed the environment variable from `GITHUB_TOKEN` to `GH_TOKEN` for consistency.