### PR TITLE
日付が失敗するのを修正

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -19,7 +19,9 @@ jobs:
     steps:
       - name: Get current date
         id: date
-        run: echo "$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "date=$(date +'%Y-%m-%d')"
+          echo "date=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
       - name: show GITHUB_REPOSITORY
         id: show-repo
         run: echo $GITHUB_REPOSITORY


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/release-draft.yml` file. The change modifies the command used to get the current date and output it to the GitHub Actions environment.

* [`.github/workflows/release-draft.yml`](diffhunk://#diff-4bdc03a5e7ae81f88649acd20d9b3cac01b9e1f388daeb6bf8a07c3fedadf71fL22-R24): Updated the `run` command to use a multi-line script for setting the date and appending it to `$GITHUB_OUTPUT`.