### PR TITLE
衝突回避

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -18,11 +18,16 @@ jobs:
         id: date
         run: |
           echo "date=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
+      - name: Release name exists?
+        id: count
+        run: |
+          RESULT=$(gh release list --json name --jq '.[] |.name') 
+          echo $RESULT | grep -c "prod-2024-12-12" >> "$GITHUB_OUTPUT"
       - name: Create Draft Release
         id: create-draft-release
         env: 
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: prod-${{ steps.date.outputs.date }}
-          RELEASE_NAME: prod-${{ steps.date.outputs.date }}
+          TAG_NAME: prod-${{ steps.date.outputs.date }}${{ steps.count.outputs.count > 0 && '-'steps.count.outputs.count || '' }}
+          RELEASE_NAME: prod-${{ steps.date.outputs.date }}${{ steps.count.outputs.count > 0 && '-'steps.count.outputs.count || '' }}
         run: |
           gh release create "$TAG_NAME" --repo="$GITHUB_REPOSITORY" --title="$RELEASE_NAME" --generate-notes --draft


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow for creating draft releases. The main improvement is the addition of a step to check if a release name already exists, and if so, increment a counter to ensure unique release names.

Changes to GitHub Actions workflow:

* [`.github/workflows/release-draft.yml`](diffhunk://#diff-4bdc03a5e7ae81f88649acd20d9b3cac01b9e1f388daeb6bf8a07c3fedadf71fR21-R31): Added a step to check if a release name already exists and increment a counter to ensure unique release names.