### PR TITLE
repo 設定

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -23,7 +23,7 @@ jobs:
         env: 
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          RESULT=$(gh release list --json name --jq '.[] |.name') 
+          RESULT=$(gh release list  --repo="$GITHUB_REPOSITORY" --json name --jq '.[] |.name') 
           echo "count=$($RESULT | grep -c 'prod-${{ steps.date.outputs.date }}')" >> "$GITHUB_OUTPUT"
       - name: Create Draft Release
         id: create-draft-release


### PR DESCRIPTION
This pull request includes a small but important change to the `.github/workflows/release-draft.yml` file. The change updates the command used to list GitHub releases to include the repository name.

* [`.github/workflows/release-draft.yml`](diffhunk://#diff-4bdc03a5e7ae81f88649acd20d9b3cac01b9e1f388daeb6bf8a07c3fedadf71fL26-R26): Modified the `gh release list` command to include the `--repo="$GITHUB_REPOSITORY"` parameter, ensuring the command runs correctly within the specified repository.