### PR TITLE
比較がおかしいのかな

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -30,7 +30,7 @@ jobs:
         id: create-draft-release
         env: 
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: prod-${{ steps.date.outputs.date }}${{ steps.count.outputs.count > 0 && '-steps.count.outputs.count' || '' }}
-          RELEASE_NAME: prod-${{ steps.date.outputs.date }}${{ steps.count.outputs.count > 0 && '-steps.count.outputs.count' || '' }}
+          TAG_NAME: prod-${{ steps.date.outputs.date }}${{ steps.count.outputs.count != 0 && '-steps.count.outputs.count' || '' }}
+          RELEASE_NAME: prod-${{ steps.date.outputs.date }}${{ steps.count.outputs.count != 0 && '-steps.count.outputs.count' || '' }}
         run: |
           gh release create "$TAG_NAME" --repo="$GITHUB_REPOSITORY" --title="$RELEASE_NAME" --generate-notes --draft


### PR DESCRIPTION
This pull request includes a minor update to the `release-draft.yml` workflow file. The change corrects the condition for appending the count to the `TAG_NAME` and `RELEASE_NAME` environment variables.

* [`.github/workflows/release-draft.yml`](diffhunk://#diff-4bdc03a5e7ae81f88649acd20d9b3cac01b9e1f388daeb6bf8a07c3fedadf71fL33-R34): Updated condition to check if `steps.count.outputs.count` is not equal to zero instead of greater than zero for `TAG_NAME` and `RELEASE_NAME`.