### PR TITLE
エラーが出たのでちょっと修正

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           RESULT=$(gh release list  --repo="$GITHUB_REPOSITORY" --json name --jq '.[] |.name') 
           NAME="prod-${{ steps.date.outputs.date }}"
-          COUNT=$(echo $RESULT | grep -c \"$NAME\")
+          COUNT=$(echo $RESULT | grep -c $NAME)
           if [ $COUNT -gt 0 ]; then
             echo "name=prod-${{ steps.date.outputs.dae }}-$COUNT" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/release-draft.yml` file. The change simplifies the `grep` command used to count the occurrences of a release name by removing unnecessary quotes around the `$NAME` variable.

Workflow improvement:

* [`.github/workflows/release-draft.yml`](diffhunk://#diff-4bdc03a5e7ae81f88649acd20d9b3cac01b9e1f388daeb6bf8a07c3fedadf71fL28-R28): Simplified the `grep` command in the `COUNT` variable assignment by removing unnecessary quotes around the `$NAME` variable.