### PR TITLE
jq でカウントさせる

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -23,12 +23,8 @@ jobs:
         env: 
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          RESULT=$(gh release list  --repo="$GITHUB_REPOSITORY" --json name --jq '.[] |.name')
-          echo $RESULT
           NAME="prod-${{ steps.date.outputs.date }}"
-          echo $NAME
-          COUNT=$(echo $RESULT | grep -c $NAME)
-          echo $COUNT
+          COUNT=$(gh release list --json name --jq 'map(select(.name | contains("$NAME"))) | length')
           if [ $COUNT -gt 0 ]; then
             echo "name=prod-${{ steps.date.outputs.date }}-$COUNT" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
This pull request includes a change to the release draft workflow in the `.github/workflows/release-draft.yml` file. The change simplifies the process of counting existing releases with a specific name pattern.

Improvements to release draft workflow:

* [`.github/workflows/release-draft.yml`](diffhunk://#diff-4bdc03a5e7ae81f88649acd20d9b3cac01b9e1f388daeb6bf8a07c3fedadf71fL26-R27): Simplified the command to count existing releases by using `gh release list` with a `jq` filter directly, reducing the number of steps and removing intermediate variable assignments.