### PR TITLE
動くように修正

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -24,7 +24,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           NAME="prod-${{ steps.date.outputs.date }}"
-          COUNT=$(gh release list --json name --jq 'map(select(.name | contains("$NAME"))) | length')
+          COUNT=$(gh release list --json name --jq "map(select(.name | contains(\"$NAME\"))) | length")
           if [ $COUNT -gt 0 ]; then
             echo "name=prod-${{ steps.date.outputs.date }}-$COUNT" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/release-draft.yml` file. The change modifies the `jq` query syntax to use double quotes instead of single quotes for better compatibility.

* [`.github/workflows/release-draft.yml`](diffhunk://#diff-4bdc03a5e7ae81f88649acd20d9b3cac01b9e1f388daeb6bf8a07c3fedadf71fL27-R27): Changed the `jq` query syntax to use double quotes around the `$NAME` variable for better compatibility.